### PR TITLE
feat(gui): Add basic player controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#13](https://github.com/MalteHerrmann/track-analyzer/pull/13) Add basic player controls.
 - [#12](https://github.com/MalteHerrmann/track-analyzer/pull/12) Add list view for folder entries.
 - [#2](https://github.com/MalteHerrmann/track-analyzer/pull/2) Add CI for linting and tests.
 - [#1](https://github.com/MalteHerrmann/track-analyzer/pull/1) Add basic GUI implementation.

--- a/gui/audio.py
+++ b/gui/audio.py
@@ -1,0 +1,110 @@
+"""
+This file contains the media player, which enables playback
+of the selected audio files.
+"""
+
+from time import sleep
+from PyQt5.QtCore import QObject, Qt, QThread, QUrl
+from PyQt5.QtMultimedia import QMediaContent, QMediaPlayer, QAudio
+from PyQt5.QtWidgets import QHBoxLayout, QPushButton, QSlider, QVBoxLayout, QWidget
+
+
+class SliderWorker(QObject):
+    """
+    Worker class for the slider.
+    """
+    pass
+
+    # def __init__(self, player: QMediaPlayer):
+    #     super().__init__()
+    #     self.player = player
+    #
+    # def set_position(self, position: int):
+    #     """
+    #     Sets the position of the audio file.
+    #     """
+    #     self.player.setPosition(self.calculate_position(position))
+    #
+    # def calculate_position(self, position: int) -> int:
+    #     """
+    #     Calculates the position of the audio file from the normalized position
+    #     value (0 < x < 100).
+    #     """
+    #     return round(position * self.player.duration() / 100)
+    #
+    # def calculate_normalized_position(self) -> int:
+    #     """
+    #     Calculates the normalized position of the audio file.
+    #     """
+    #     return round(self.player.position() * 100 / self.player.duration())
+
+
+class AudioPlayer(QWidget):
+    """
+    Creates an instance of the audio player.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        self.slider = QSlider(Qt.Orientation.Horizontal)
+        layout.addWidget(self.slider)
+
+        buttons = QWidget()
+        button_layout = QHBoxLayout()
+        buttons.setLayout(button_layout)
+        layout.addWidget(buttons)
+
+        stop_button = QPushButton("Stop")
+        button_layout.addWidget(stop_button)
+
+        play_button = QPushButton("Play")
+        button_layout.addWidget(play_button)
+
+        self.player = QMediaPlayer()
+        self.player.setAudioRole(QAudio.MusicRole)
+
+        stop_button.clicked.connect(self.stop)
+        play_button.clicked.connect(self.play)
+        self.slider.valueChanged.connect(self.set_position)
+
+    def load_track(self, track: str):
+        """
+        Loads the selected audio file.
+        """
+        self.media_content = QMediaContent(QUrl.fromLocalFile(track))
+        self.player.setMedia(self.media_content)
+
+    def play(self):
+        """
+        Plays the selected audio file.
+        """
+        self.player.play()
+
+    def stop(self):
+        """
+        Stops the selected audio file.
+        """
+        self.player.stop()
+
+    def set_position(self, position: int):
+        """
+        Sets the position of the audio file.
+        """
+        self.player.setPosition(self.calculate_position(position))
+
+    def calculate_position(self, position: int) -> int:
+        """
+        Calculates the position of the audio file from the normalized position
+        value (0 < x < 100).
+        """
+        return round(position * self.player.duration() / 100)
+
+    def calculate_normalized_position(self) -> int:
+        """
+        Calculates the normalized position of the audio file.
+        """
+        return round(self.player.position() * 100 / self.player.duration())

--- a/gui/audio.py
+++ b/gui/audio.py
@@ -13,6 +13,7 @@ class SliderWorker(QObject):
     """
     Worker class for the slider.
     """
+
     pass
 
     # def __init__(self, player: QMediaPlayer):

--- a/gui/audio.py
+++ b/gui/audio.py
@@ -3,41 +3,9 @@ This file contains the media player, which enables playback
 of the selected audio files.
 """
 
-from time import sleep
-from PyQt5.QtCore import QObject, Qt, QThread, QUrl
-from PyQt5.QtMultimedia import QMediaContent, QMediaPlayer, QAudio
+from PyQt5.QtCore import Qt, QUrl
+from PyQt5.QtMultimedia import QAudio, QMediaContent, QMediaPlayer
 from PyQt5.QtWidgets import QHBoxLayout, QPushButton, QSlider, QVBoxLayout, QWidget
-
-
-class SliderWorker(QObject):
-    """
-    Worker class for the slider.
-    """
-
-    pass
-
-    # def __init__(self, player: QMediaPlayer):
-    #     super().__init__()
-    #     self.player = player
-    #
-    # def set_position(self, position: int):
-    #     """
-    #     Sets the position of the audio file.
-    #     """
-    #     self.player.setPosition(self.calculate_position(position))
-    #
-    # def calculate_position(self, position: int) -> int:
-    #     """
-    #     Calculates the position of the audio file from the normalized position
-    #     value (0 < x < 100).
-    #     """
-    #     return round(position * self.player.duration() / 100)
-    #
-    # def calculate_normalized_position(self) -> int:
-    #     """
-    #     Calculates the normalized position of the audio file.
-    #     """
-    #     return round(self.player.position() * 100 / self.player.duration())
 
 
 class AudioPlayer(QWidget):
@@ -67,6 +35,7 @@ class AudioPlayer(QWidget):
 
         self.player = QMediaPlayer()
         self.player.setAudioRole(QAudio.MusicRole)
+        self.media_content = QMediaContent()
 
         stop_button.clicked.connect(self.stop)
         play_button.clicked.connect(self.play)

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import QApplication, QMainWindow, QPushButton, QVBoxLayout,
 
 from audio import ID3File
 from config import load_available_tags
+from gui.audio import AudioPlayer
 from gui.file_dialog import DirDialog
 from gui.genre_selector import GenreSelector
 from gui.tag_list import TagList
@@ -47,6 +48,9 @@ class MainWindow(QMainWindow):
         track_list = TrackList()
         layout.addWidget(track_list)
 
+        player = AudioPlayer()
+        layout.addWidget(player)
+
         genre_selector = GenreSelector(self.available_tags, self.selected_genre)
         layout.addWidget(genre_selector)
 
@@ -65,6 +69,7 @@ class MainWindow(QMainWindow):
         )
         # Load track when selecting from list
         track_list.listbox.itemClicked.connect(lambda x: self.load_track(x.text()))
+        track_list.listbox.itemClicked.connect(lambda x: player.load_track(x.text()))
         # Update available tags when changing genre
         genre_selector.combobox.currentTextChanged.connect(
             lambda x: self.tag_list.update_tags(x)

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -71,9 +71,7 @@ class MainWindow(QMainWindow):
         track_list.listbox.itemClicked.connect(lambda x: self.load_track(x.text()))
         track_list.listbox.itemClicked.connect(lambda x: player.load_track(x.text()))
         # Update available tags when changing genre
-        genre_selector.combobox.currentTextChanged.connect(
-            lambda x: self.tag_list.update_tags(x)
-        )
+        genre_selector.combobox.currentTextChanged.connect(self.tag_list.update_tags)
         # Apply changes upon button press
         apply_button.clicked.connect(self.apply)
 


### PR DESCRIPTION
This PR adds player controls to the main window of the application. Note, that at the current state, the slider is useful for skipping through the track but not yet being updated with the track playing.

----

Closes #5 